### PR TITLE
Update hive gateway to v2 + production like setup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,13 +78,15 @@ env.ROUTER_CONFIG_FILE_PATH = "/gateways/hive-router/config.yaml"
 
 [gateways.hive-gateway]
 label = "Hive Gateway"
-image = "ghcr.io/graphql-hive/gateway:1.16.3"
-args = ["supergraph", "/supergraph/schema.graphql", "-p", "4000", "-c", "/gateways/hive-gateway/config.ts"]
+image = "ghcr.io/graphql-hive/gateway:2.1.2"
+env.NODE_ENV = "production"
+args = ["supergraph", "/supergraph/schema.graphql", "-p", "4000", "-c", "/gateways/hive-gateway/config.ts", "--jit", "--fork", "3"]
 
 [gateways.hive-gateway-no-cache]
 label = "Hive Gateway (no cache?)"
-image = "ghcr.io/graphql-hive/gateway:1.16.3"
-args = ["supergraph", "/supergraph/schema.graphql", "-p", "4000", "-c", "/gateways/hive-gateway/no-cache.config.ts"]
+image = "ghcr.io/graphql-hive/gateway:2.1.2"
+env.NODE_ENV = "production"
+args = ["supergraph", "/supergraph/schema.graphql", "-p", "4000", "-c", "/gateways/hive-gateway/no-cache.config.ts", "--jit", "--fork", "3"]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SCENARIOS


### PR DESCRIPTION
This PR aims to update the Hive Gateway to the latest setup and enable the recommended options for a production like environment.

I didn't have the opportunity to actually test this since I failed to run the benchmark on macOS. Don't hesitate to post results in the comments! We would be happy to see if it makes any difference 🙂